### PR TITLE
fix: Add management_protocol and datapath_id fields

### DIFF
--- a/backend/app/api/nbi/devices.py
+++ b/backend/app/api/nbi/devices.py
@@ -47,6 +47,8 @@ async def list_devices(
                 "vendor": d.vendor,
                 "model": d.model,
                 "role": d.role,
+                "management_protocol": d.management_protocol,
+                "datapath_id": d.datapath_id,
             }
             for d in devices
         ]
@@ -143,6 +145,8 @@ async def get_device_info(device_id: str):
                 # === NBI/ODL Fields ===
                 "node_id": device.node_id,
                 "vendor": device.vendor,
+                "management_protocol": getattr(device, 'management_protocol', 'NETCONF'),
+                "datapath_id": getattr(device, 'datapath_id', None),
                 "odl_mounted": device.odl_mounted,
                 "odl_connection_status": device.odl_connection_status,
                 "last_synced_at": device.last_synced_at.isoformat() if device.last_synced_at else None,

--- a/backend/app/models/device_network.py
+++ b/backend/app/models/device_network.py
@@ -52,7 +52,9 @@ class DeviceVendor(str, Enum):
     ARISTA = "ARISTA"
     OTHER = "OTHER"
 
-
+class ManagementProtocol(str, Enum):
+    NETCONF = "NETCONF"
+    OPENFLOW = "OPENFLOW"
 
 class DeviceNetworkBase(BaseModel):
     serial_number: str = Field(..., description="Serial Number (ต้องไม่ซ้ำ)", min_length=1, max_length=100)
@@ -80,6 +82,10 @@ class DeviceNetworkBase(BaseModel):
         max_length=63
     )
     vendor: DeviceVendor = Field(default=DeviceVendor.OTHER, description="Vendor สำหรับเลือก driver")
+    
+    # Management Protocol Fields
+    management_protocol: ManagementProtocol = Field(default=ManagementProtocol.NETCONF, description="Protocol สำหรับจัดการ (NETCONF หรือ OPENFLOW)")
+    datapath_id: Optional[str] = Field(None, description="OpenFlow datapath_id (เช่น 0000000000000001)")
     
     # NETCONF Connection Fields (สำหรับ Mount)
     netconf_host: Optional[str] = Field(None, description="IP/Hostname สำหรับ NETCONF connection")
@@ -117,6 +123,10 @@ class DeviceNetworkUpdate(BaseModel):
     # NBI/ODL Fields
     node_id: Optional[str] = Field(None, description="ODL node-id สำหรับ topology-netconf", max_length=63)
     vendor: Optional[DeviceVendor] = Field(None, description="Vendor สำหรับเลือก driver")
+    
+    # Management Protocol Fields
+    management_protocol: Optional[ManagementProtocol] = Field(None, description="Protocol สำหรับจัดการ (NETCONF หรือ OPENFLOW)")
+    datapath_id: Optional[str] = Field(None, description="OpenFlow datapath_id")
     
     # NETCONF Connection Fields
     netconf_host: Optional[str] = Field(None, description="IP/Hostname สำหรับ NETCONF connection")
@@ -185,6 +195,8 @@ class DeviceNetworkResponse(BaseModel):
     # NBI/ODL Fields - node_id is OPTIONAL in response (for backward compatibility)
     node_id: Optional[str] = Field(None, description="ODL node-id (unique, URL-safe)")
     vendor: Optional[str] = Field(None, description="Vendor สำหรับเลือก driver")
+    management_protocol: Optional[str] = Field(None, description="Protocol สำหรับจัดการ")
+    datapath_id: Optional[str] = Field(None, description="OpenFlow datapath_id")
     
     # NETCONF Connection Fields
     netconf_host: Optional[str] = Field(None, description="IP/Hostname สำหรับ NETCONF")

--- a/backend/app/schemas/device_profile.py
+++ b/backend/app/schemas/device_profile.py
@@ -33,3 +33,5 @@ class DeviceProfile(BaseModel):
     os_type: Optional[str] = None # "CISCO_IOS_XE" | "HUAWEI_VRP" | "CISCO_IOS" | "CISCO_NXOS" | etc.
     model: Optional[str] = None
     role: str = "router"        # router | switch
+    management_protocol: str = "NETCONF"
+    datapath_id: Optional[str] = None

--- a/backend/app/services/device_network_service.py
+++ b/backend/app/services/device_network_service.py
@@ -117,6 +117,8 @@ class DeviceNetworkService:
                 # NBI fields
                 "node_id": device_data.node_id,
                 "vendor": device_data.vendor.value if hasattr(device_data.vendor, 'value') else device_data.vendor,
+                "management_protocol": device_data.management_protocol.value if hasattr(device_data.management_protocol, 'value') else device_data.management_protocol,
+                "datapath_id": device_data.datapath_id,
                 
                 # NETCONF fields (from input or defaults)
                 "netconf_host": device_data.netconf_host or device_data.ip_address,
@@ -237,6 +239,8 @@ class DeviceNetworkService:
             # NBI/ODL Fields
             node_id=getattr(device, 'node_id', None),
             vendor=getattr(device, 'vendor', 'OTHER'),
+            management_protocol=getattr(device, 'management_protocol', 'NETCONF'),
+            datapath_id=getattr(device, 'datapath_id', None),
             netconf_host=getattr(device, 'netconf_host', None),
             netconf_port=getattr(device, 'netconf_port', 830) or 830,
             netconf_username=getattr(device, 'netconf_username', None),
@@ -425,6 +429,11 @@ class DeviceNetworkService:
             if update_data.vendor is not None:
                 update_dict["vendor"] = update_data.vendor.value
 
+            if update_data.management_protocol is not None:
+                update_dict["management_protocol"] = update_data.management_protocol.value
+
+            if update_data.datapath_id is not None:
+                update_dict["datapath_id"] = update_data.datapath_id
 
             # NETCONF Connection Fields
             if update_data.netconf_host is not None:

--- a/backend/app/services/device_profile_service_db.py
+++ b/backend/app/services/device_profile_service_db.py
@@ -66,6 +66,8 @@ class DeviceProfileService:
             os_type=os_type,
             model=db_device.device_model,
             role=role,
+            management_protocol=db_device.management_protocol or "NETCONF",
+            datapath_id=db_device.datapath_id,
         )
     
     async def get(self, device_id: str) -> DeviceProfile:


### PR DESCRIPTION
Introduce management_protocol (enum: NETCONF/OPENFLOW) and datapath_id to device network models and schemas, and wire them through API and services. Updated DeviceNetworkBase/Update/Response, DeviceProfile schema, NBI devices list/detail responses, DeviceNetworkService serialization/update logic, and DeviceProfileService DB mapping to include defaults (NETCONF) and preserve backward compatibility via getattr/defaults. This enables representing OpenFlow devices and their datapath IDs while keeping NETCONF as the default management protocol.