### PR TITLE
Add phpIPAM integration & IPAM notifications

### DIFF
--- a/backend/app/api/device_networks.py
+++ b/backend/app/api/device_networks.py
@@ -100,7 +100,7 @@ async def create_device(
         # Require ENGINEER or ADMIN
         check_engineer_permission(current_user)
 
-        device = await device_svc.create_device(device_data)
+        device, ipam_notifications = await device_svc.create_device(device_data)
         
         if not device:
             raise HTTPException(
@@ -110,7 +110,8 @@ async def create_device(
 
         return DeviceNetworkCreateResponse(
             message="Device created successfully",
-            device=device
+            device=device,
+            ipam_notifications=ipam_notifications
         )
 
     except ValueError as e:
@@ -137,7 +138,7 @@ async def update_device(
         # Require ENGINEER or ADMIN
         check_engineer_permission(current_user)
 
-        device = await device_svc.update_device(device_id, update_data)
+        device, ipam_notifications = await device_svc.update_device(device_id, update_data)
         
         if not device:
             raise HTTPException(
@@ -147,7 +148,8 @@ async def update_device(
 
         return DeviceNetworkUpdateResponse(
             message="Device updated successfully",
-            device=device
+            device=device,
+            ipam_notifications=ipam_notifications
         )
 
     except ValueError as e:
@@ -176,7 +178,7 @@ async def delete_device(
                 detail="User role {current_user['role']} is not allowed to delete device"
             )
 
-        success = await device_svc.delete_device(device_id)
+        success, ipam_notifications = await device_svc.delete_device(device_id)
         
         if not success:
             raise HTTPException(
@@ -185,7 +187,8 @@ async def delete_device(
             )
 
         return DeviceNetworkDeleteResponse(
-            message="Device deleted successfully"
+            message="Device deleted successfully",
+            ipam_notifications=ipam_notifications
         )
 
     except ValueError as e:

--- a/backend/app/api/interfaces.py
+++ b/backend/app/api/interfaces.py
@@ -36,6 +36,7 @@ from app.models.interface import (
     InterfaceStatus,
     InterfaceType
 )
+from app.services.phpipam_service import PhpipamService
 from prisma import Prisma
 
 router = APIRouter(prefix="/interfaces", tags=["Network Interfaces"])
@@ -236,7 +237,7 @@ async def get_interfaces_from_db(
             }
 
         # 3. Format response
-        interfaces = []
+        result_interfaces = []
         for intf in db_interfaces:
             ipv4 = None
             if intf.ip_address and intf.subnet_mask:
@@ -244,7 +245,7 @@ async def get_interfaces_from_db(
             elif intf.ip_address:
                 ipv4 = intf.ip_address
 
-            interfaces.append({
+            result_interfaces.append({
                 "name": intf.name,
                 "type": intf.type or "OTHER",
                 "number": str(intf.port_number) if intf.port_number is not None else "",
@@ -259,14 +260,15 @@ async def get_interfaces_from_db(
                 "duplex": intf.duplex,
                 "mtu": intf.mtu,
                 "oper_status": None,
+                "phpipam_address_id": intf.phpipam_address_id,
             })
 
         return {
             "success": True,
             "node_id": node_id,
             "source": "database",
-            "count": len(interfaces),
-            "interfaces": interfaces,
+            "count": len(result_interfaces),
+            "interfaces": result_interfaces,
         }
 
     except HTTPException:
@@ -435,6 +437,53 @@ async def sync_interfaces(
                     },
                 )
 
+        # ── Step 3c: IPAM auto-book discovered IPs ────────────────────────
+        ipam_notifications = []
+        phpipam_svc = PhpipamService()
+
+        if phpipam_svc.enabled and rows_to_upsert:
+            for row in rows_to_upsert:
+                ip_addr = row.get("ip_address")
+                if not ip_addr:
+                    continue
+
+                try:
+                    result = await phpipam_svc.book_ip(
+                        ip_address=ip_addr,
+                        hostname=f"{node_id}-{row['name']}",
+                        mac_address=row.get("mac_address"),
+                        purpose="Interface IP"
+                    )
+
+                    if result.get("success") and result.get("phpipam_address_id"):
+                        # Update interface record with phpipam_address_id
+                        await prisma.interface.update_many(
+                            where={
+                                "device_id": db_device_id,
+                                "name": row["name"],
+                            },
+                            data={
+                                "phpipam_address_id": result["phpipam_address_id"]
+                            },
+                        )
+
+                    ipam_notifications.append({
+                        "interface": row["name"],
+                        "ip_address": ip_addr,
+                        "code": result.get("code"),
+                        "phpipam_address_id": result.get("phpipam_address_id"),
+                        "message": result.get("error_message") or result.get("code"),
+                    })
+                except Exception as ipam_e:
+                    logger.warning(f"IPAM auto-book failed for {ip_addr}: {ipam_e}")
+                    ipam_notifications.append({
+                        "interface": row["name"],
+                        "ip_address": ip_addr,
+                        "code": "IPAM_ERROR",
+                        "phpipam_address_id": None,
+                        "message": str(ipam_e),
+                    })
+
         # ── Step 4: Read-back from DB (source of truth) ──────────────────
         db_interfaces = await prisma.interface.find_many(
             where={"device_id": db_device_id},
@@ -464,6 +513,7 @@ async def sync_interfaces(
                 "duplex": intf.duplex,
                 "mtu": intf.mtu,
                 "oper_status": None,
+                "phpipam_address_id": intf.phpipam_address_id,
             })
 
         return {
@@ -474,6 +524,7 @@ async def sync_interfaces(
             "synced_count": synced_count,
             "count": len(result_interfaces),
             "interfaces": result_interfaces,
+            "ipam_notifications": ipam_notifications,
         }
 
     except HTTPException:

--- a/backend/app/api/ipam.py
+++ b/backend/app/api/ipam.py
@@ -7,7 +7,10 @@ from app.models.ipam import (
     DeviceIpAssignRequest, InterfaceIpAssignRequest, IpAssignmentResponse,
     SyncRequest, SyncResponse,
     SubnetCreateRequest, SubnetUpdateRequest, SubnetDetailResponse, SubnetUsageResponse,
-    SectionResponse, SectionListResponse, SectionCreateRequest, SectionUpdateRequest
+    SectionResponse, SectionListResponse, SectionCreateRequest, SectionUpdateRequest,
+    SubnetPickerItem, SubnetPickerResponse,
+    AvailableIpListResponse,
+    SpaceMapEntry, SpaceMapResponse
 )
 from app.services.phpipam_service import PhpipamService
 from app.database import get_prisma_client, is_prisma_client_ready
@@ -80,6 +83,51 @@ async def get_subnets(
             detail=f"Error fetching subnets: {str(e)}"
         )
 
+
+# ========= IPAM Picker Endpoints (MUST be before /subnets/{subnet_id}) =========
+
+@router.get("/subnets/picker", response_model=SubnetPickerResponse)
+async def get_subnets_for_picker(
+    current_user: dict = Depends(get_current_user)
+):
+    """
+    Return subnet list with usage info for dropdown picker.
+    ใช้ใน Device/Interface form เพื่อให้ user เลือก subnet จาก dropdown
+    """
+    try:
+        phpipam_svc = get_phpipam_service()
+        
+        if not phpipam_svc.enabled:
+            return SubnetPickerResponse(subnets=[], total=0)
+        
+        picker_items = await phpipam_svc.get_subnets_for_picker()
+        
+        subnet_list = [
+            SubnetPickerItem(
+                id=item["id"],
+                label=item["label"],
+                subnet=item["subnet"],
+                mask=item["mask"],
+                description=item.get("description"),
+                usage_percent=item.get("usage_percent"),
+                free_hosts=item.get("free_hosts"),
+                total_hosts=item.get("total_hosts"),
+            )
+            for item in picker_items
+        ]
+        
+        return SubnetPickerResponse(
+            subnets=subnet_list,
+            total=len(subnet_list)
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error fetching subnets for picker: {str(e)}"
+        )
 
 @router.get("/subnets/{subnet_id}/addresses", response_model=IpAddressListResponse)
 async def get_subnet_addresses(
@@ -1193,4 +1241,91 @@ async def get_subnet_children(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Error fetching child subnets: {str(e)}"
+        )
+
+
+
+@router.get("/subnets/{subnet_id}/available", response_model=AvailableIpListResponse)
+async def get_available_ips(
+    subnet_id: str,
+    limit: int = Query(100, ge=1, le=1000, description="จำนวน IP ที่ต้องการดึงมาแสดง"),
+    current_user: dict = Depends(get_current_user)
+):
+    """
+    Return list of available (free) IPs in a subnet.
+    ใช้ใน dropdown ตัวที่สอง หลังจาก user เลือก subnet แล้ว
+    """
+    try:
+        phpipam_svc = get_phpipam_service()
+        
+        if not phpipam_svc.enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="phpIPAM integration is not enabled"
+            )
+        
+        result = await phpipam_svc.get_available_ips(subnet_id, limit=limit)
+        
+        return AvailableIpListResponse(
+            subnet_id=result["subnet_id"],
+            subnet=result["subnet"],
+            available_ips=result["available_ips"],
+            total_available=result["total_available"]
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error fetching available IPs: {str(e)}"
+        )
+
+
+@router.get("/subnets/{subnet_id}/space-map", response_model=SpaceMapResponse)
+async def get_subnet_space_map(
+    subnet_id: str,
+    current_user: dict = Depends(get_current_user)
+):
+    """
+    Return visual space map of a subnet.
+    แสดง IP ทั้งหมดใน subnet พร้อมสถานะ (used/free/gateway/reserved)
+    """
+    try:
+        phpipam_svc = get_phpipam_service()
+        
+        if not phpipam_svc.enabled:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="phpIPAM integration is not enabled"
+            )
+        
+        result = await phpipam_svc.get_space_map(subnet_id)
+        
+        addresses = [
+            SpaceMapEntry(
+                ip=addr["ip"],
+                status=addr["status"],
+                hostname=addr.get("hostname"),
+                description=addr.get("description")
+            )
+            for addr in result.get("addresses", [])
+        ]
+        
+        return SpaceMapResponse(
+            subnet_id=result["subnet_id"],
+            subnet=result["subnet"],
+            mask=result["mask"],
+            total_hosts=result["total_hosts"],
+            used=result["used"],
+            free=result["free"],
+            addresses=addresses
+        )
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Error fetching space map: {str(e)}"
         )

--- a/backend/app/models/device_network.py
+++ b/backend/app/models/device_network.py
@@ -68,6 +68,9 @@ class DeviceNetworkBase(BaseModel):
     description: Optional[str] = Field(None, description="คำอธิบายอุปกรณ์", max_length=1000)
     phpipam_address_id: Optional[str] = Field(None, description="phpIPAM Address ID")
     
+    # IPAM Picker mode — ถ้า user เลือก subnet จาก dropdown
+    ipam_subnet_id: Optional[str] = Field(None, description="Subnet ID จาก phpIPAM (Picker mode)")
+    
     # Foreign Keys
     policy_id: Optional[str] = Field(None, description="Policy ID")
     os_id: Optional[str] = Field(None, description="Operating System ID")
@@ -250,13 +253,25 @@ class DeviceNetworkListResponse(BaseModel):
 class DeviceNetworkCreateResponse(BaseModel):
     message: str
     device: DeviceNetworkResponse
+    ipam_notifications: list = Field(
+        default_factory=list,
+        description="แจ้งเตือนสถานะการ book IP ใน phpIPAM"
+    )
 
 class DeviceNetworkUpdateResponse(BaseModel):
     message: str
     device: DeviceNetworkResponse
+    ipam_notifications: list = Field(
+        default_factory=list,
+        description="แจ้งเตือนสถานะการ book/release IP ใน phpIPAM"
+    )
 
 class DeviceNetworkDeleteResponse(BaseModel):
     message: str
+    ipam_notifications: list = Field(
+        default_factory=list,
+        description="แจ้งเตือนสถานะการปล่อย IP จาก phpIPAM"
+    )
 
 
 class DeviceTagAssignment(BaseModel):

--- a/backend/app/models/interface.py
+++ b/backend/app/models/interface.py
@@ -64,6 +64,17 @@ class InterfaceResponse(BaseModel):
     port_number: Optional[int]
     mac_address: Optional[str]
     
+    # IPAM Integration Fields
+    ip_address: Optional[str] = Field(None, description="IP Address ที่ assign ให้ interface")
+    subnet_mask: Optional[str] = Field(None, description="Subnet mask (e.g. 255.255.255.0 or /24)")
+    gateway: Optional[str] = Field(None, description="Default gateway")
+    phpipam_address_id: Optional[str] = Field(None, description="phpIPAM address record ID")
+    
+    # ODL Operational Fields
+    speed: Optional[int] = Field(None, description="Interface speed in Mbps")
+    duplex: Optional[str] = Field(None, description="Duplex mode")
+    mtu: Optional[int] = Field(None, description="MTU in bytes")
+    
     created_at: datetime
     updated_at: datetime
     

--- a/backend/app/models/ipam.py
+++ b/backend/app/models/ipam.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, IPvAnyAddress
 from typing import Optional, List, Union
 from datetime import datetime
+from enum import Enum
 
 
 # ========= Subnet Models =========
@@ -206,3 +207,83 @@ class SectionResponse(BaseModel):
 class SectionListResponse(BaseModel):
     sections: List[SectionResponse]
     total: int
+
+
+# ========= IPAM Notification System =========
+
+class IpamNotificationCode(str, Enum):
+    """สถานะการ book/release IP ใน phpIPAM"""
+    BOOKED = "IPAM_BOOKED"                    # book IP ใหม่สำเร็จ
+    ALREADY_EXISTS = "IPAM_ALREADY_EXISTS"    # IP มีอยู่แล้วใน phpIPAM (reuse)
+    CONFLICT = "IPAM_CONFLICT"                # phpIPAM reject — IP ซ้ำ/overlap
+    NO_SUBNET = "IPAM_NO_SUBNET"              # ไม่เจอ subnet ที่ match กับ IP นี้
+    DISABLED = "IPAM_DISABLED"                # phpIPAM ถูกปิดอยู่
+    RELEASED = "IPAM_RELEASED"                # ปล่อย IP สำเร็จ
+    RELEASE_FAILED = "IPAM_RELEASE_FAILED"    # ปล่อย IP ไม่สำเร็จ
+
+
+class IpamNotification(BaseModel):
+    """Notification ส่งกลับ Frontend เพื่อแสดง Snackbar"""
+    code: str                                  # IpamNotificationCode value
+    severity: str                              # "success" | "info" | "warning" | "error"
+    message: str                               # Human-readable message
+    ip_address: Optional[str] = None
+    subnet: Optional[str] = None               # e.g. "10.10.5.0/24"
+    phpipam_address_id: Optional[str] = None
+
+
+class IpamResult(BaseModel):
+    """Internal result จาก IPAM booking — ใช้ภายใน service"""
+    success: bool
+    code: str                                  # IpamNotificationCode value
+    phpipam_address_id: Optional[str] = None
+    ip_address: Optional[str] = None
+    subnet_info: Optional[str] = None          # e.g. "10.10.5.0/24"
+    error_message: Optional[str] = None
+
+
+# ========= Subnet Picker Models (สำหรับ dropdown) =========
+
+class SubnetPickerItem(BaseModel):
+    """แต่ละ item ใน dropdown เลือก subnet"""
+    id: str
+    label: str                                 # "10.10.5.0/24 — Management Network (240 free)"
+    subnet: str                                # "10.10.5.0"
+    mask: str                                  # "24"
+    description: Optional[str] = None
+    usage_percent: Optional[float] = None      # % ที่ใช้ไปแล้ว
+    free_hosts: Optional[int] = None           # จำนวน IP ว่าง
+    total_hosts: Optional[int] = None          # จำนวน IP ทั้งหมด
+
+
+class SubnetPickerResponse(BaseModel):
+    subnets: List[SubnetPickerItem]
+    total: int
+
+
+# ========= Available IPs (สำหรับ dropdown เลือก IP) =========
+
+class AvailableIpListResponse(BaseModel):
+    subnet_id: str
+    subnet: str                                # "10.10.5.0/24"
+    available_ips: List[str]
+    total_available: int
+
+
+# ========= Space Map Models (สำหรับ visual IP map) =========
+
+class SpaceMapEntry(BaseModel):
+    ip: str
+    status: str                                # "used" | "free" | "offline" | "gateway" | "reserved"
+    hostname: Optional[str] = None
+    description: Optional[str] = None
+
+
+class SpaceMapResponse(BaseModel):
+    subnet_id: str
+    subnet: str
+    mask: str
+    total_hosts: int
+    used: int
+    free: int
+    addresses: List[SpaceMapEntry]

--- a/backend/app/services/device_network_service.py
+++ b/backend/app/services/device_network_service.py
@@ -16,9 +16,39 @@ from app.models.device_network import (
 class DeviceNetworkService:
     #Service สำหรับจัดการ Device Network
 
+    # Notification template map
+    _NOTIFICATION_MAP = {
+        "IPAM_BOOKED": ("success", "IP {ip} ถูกจองใน phpIPAM สำเร็จ (Subnet: {subnet})"),
+        "IPAM_ALREADY_EXISTS": ("info", "IP {ip} มีอยู่ใน phpIPAM อยู่แล้ว — อัปเดต hostname/MAC แล้วใช้ record เดิม"),
+        "IPAM_CONFLICT": ("error", "IP {ip} ขัดแย้งกับ IP อื่นใน phpIPAM: {error}"),
+        "IPAM_NO_SUBNET": ("warning", "ไม่เจอ subnet ที่ครอบคลุม IP {ip} ใน phpIPAM — IP ถูกบันทึกในระบบแต่ไม่ได้จองใน IPAM"),
+        "IPAM_DISABLED": ("info", "phpIPAM ถูกปิดอยู่ — IP ถูกบันทึกในระบบเท่านั้น"),
+        "IPAM_RELEASED": ("success", "IP {ip} ถูกปล่อยเป็น IP ว่างใน phpIPAM สำเร็จ (ยังเก็บ record ไว้)"),
+        "IPAM_RELEASE_FAILED": ("warning", "ไม่สามารถปล่อย IP จาก phpIPAM ได้ — อาจต้องจัดการ manual"),
+    }
+
     def __init__(self, prisma_client):
         self.prisma = prisma_client
         self.phpipam_service = PhpipamService()
+
+    def _build_ipam_notification(self, result: dict) -> dict:
+        """แปลง IpamResult dict เป็น notification dict สำหรับ Frontend"""
+        code = result.get("code", "")
+        severity, msg_tpl = self._NOTIFICATION_MAP.get(
+            code, ("info", result.get("error_message") or "Unknown IPAM status")
+        )
+        return {
+            "code": code,
+            "severity": severity,
+            "message": msg_tpl.format(
+                ip=result.get("ip_address") or "N/A",
+                subnet=result.get("subnet_info") or "N/A",
+                error=result.get("error_message") or ""
+            ),
+            "ip_address": result.get("ip_address"),
+            "subnet": result.get("subnet_info"),
+            "phpipam_address_id": result.get("phpipam_address_id"),
+        }
 
     async def _sync_ip_to_phpipam(self, ip_address: str, hostname: str, mac_address: Optional[str] = None) -> Optional[str]:
         #เช็คว่า IP นี้อยู่ใน phpIPAM หรือยัง ถ้ายังหา Subnet ที่ตรงแล้วไปจอง (Step 2)
@@ -84,9 +114,11 @@ class DeviceNetworkService:
             if not template:
                 raise ValueError(f"ไม่พบ Configuration Template ID: {data['configuration_template_id']}")
 
-    async def create_device(self, device_data: DeviceNetworkCreate) -> Optional[DeviceNetworkResponse]:
-        #สร้าง Device Network ใหม่
+    async def create_device(self, device_data: DeviceNetworkCreate) -> tuple:
+        """สร้าง Device Network ใหม่ — returns (DeviceNetworkResponse, ipam_notifications)"""
         try:
+            ipam_notifications = []
+
             #ตรวจสอบว่า serial_number ซ้ำหรือไม่
             existing_device = await self.prisma.devicenetwork.find_unique(
                 where={"serial_number": device_data.serial_number}
@@ -118,35 +150,41 @@ class DeviceNetworkService:
                 if existing_node:
                     raise ValueError(f"node_id '{device_data.node_id}' มีอยู่ในระบบแล้ว")
 
-            # จัดการนำ Management IP ไปผูกกับ phpIPAM อัตโนมัติ (Step 2)
-            netconf_host = device_data.netconf_host or device_data.ip_address
+            # ======= IPAM: Book IPs =======
+            mgmt_ip = device_data.ip_address
+            netconf_ip = device_data.netconf_host
             resolved_phpipam_id = device_data.phpipam_address_id
-            
-            if netconf_host and not resolved_phpipam_id:
-                resolved_phpipam_id = await self._sync_ip_to_phpipam(
-                    ip_address=netconf_host,
+            ipam_subnet_id = getattr(device_data, 'ipam_subnet_id', None)
+
+            print(f"[IPAM-CREATE] mgmt_ip={mgmt_ip}, netconf_ip={netconf_ip}, resolved_phpipam_id={resolved_phpipam_id}, subnet_id={ipam_subnet_id}, phpipam_enabled={self.phpipam_service.enabled}")
+
+            if mgmt_ip:
+                # Always attempt to book — book_ip handles dedup internally (ALREADY_EXISTS)
+                result = await self.phpipam_service.book_ip(
+                    ip_address=mgmt_ip,
                     hostname=device_data.device_name,
-                    mac_address=device_data.mac_address
+                    mac_address=device_data.mac_address,
+                    subnet_id=ipam_subnet_id,
+                    purpose="Management IP",
+                    device_status="OFFLINE"
                 )
+                print(f"[IPAM-CREATE] mgmt_ip book result: {result}")
+                ipam_notifications.append(self._build_ipam_notification(result))
+                if result.get("success"):
+                    resolved_phpipam_id = result.get("phpipam_address_id")
 
-            #สร้าง Device — only include required fields, add optional fields conditionally
-            create_data = {
-                    "serial_number": device_data.serial_number,
-                    "device_name": device_data.device_name,
-                    "device_model": device_data.device_model,
-                    "type": device_data.type.value if hasattr(device_data.type, 'value') else device_data.type,
-                    "status": "OFFLINE", # Force status to OFFLINE explicitly
-                    "mac_address": device_data.mac_address,
-            }
+            if netconf_ip and netconf_ip != mgmt_ip:
+                nc_result = await self.phpipam_service.book_ip(
+                    ip_address=netconf_ip,
+                    hostname=device_data.device_name,
+                    mac_address=device_data.mac_address,
+                    subnet_id=None,
+                    purpose="Netconf Host",
+                    device_status="OFFLINE"
+                )
+                print(f"[IPAM-CREATE] netconf_ip book result: {nc_result}")
+                ipam_notifications.append(self._build_ipam_notification(nc_result))
 
-            # Optional fields — only include if they have values
-            if device_data.ip_address:
-                create_data["ip_address"] = device_data.ip_address
-            if device_data.description:
-                create_data["description"] = device_data.description
-            if device_data.policy_id:
-                create_data["policy_id"] = device_data.policy_id
-            # Optional fields — only include if they have values
             # Prepare manual dictionary for Prisma create to avoid Pydantic serialization issues
             create_data_dict = {
                 "serial_number": device_data.serial_number,
@@ -178,11 +216,9 @@ class DeviceNetworkService:
                 "odl_connection_status": "UNABLE_TO_CONNECT"
             }
 
-            # Filter out None values to prevent "Could not find field" errors if engine is strict or schema mismatch
-            # This ensures we only send fields that actually have values
+            # Filter out None values to prevent "Could not find field" errors
             final_create_data = {k: v for k, v in create_data_dict.items() if v is not None}
             
-            # DEBUG: Print create payload
             print(f"DEBUG CREATE DEVICE PAYLOAD (FILTERED): {final_create_data}")
             
             device = await self.prisma.devicenetwork.create(
@@ -195,7 +231,7 @@ class DeviceNetworkService:
                 }
             )
 
-            return self._build_device_response(device)
+            return self._build_device_response(device), ipam_notifications
 
         except Exception as e:
             print(f"Error creating device: {e}")
@@ -279,6 +315,7 @@ class DeviceNetworkService:
             ip_address=getattr(device, 'ip_address', None),
             mac_address=device.mac_address,
             description=getattr(device, 'description', None),
+            phpipam_address_id=getattr(device, 'phpipam_address_id', None),
             policy_id=getattr(device, 'policy_id', None),
             os_id=getattr(device, 'os_id', None),
             backup_id=getattr(device, 'backup_id', None),
@@ -391,9 +428,11 @@ class DeviceNetworkService:
             print(f"Error getting device by id: {e}")
             return None
 
-    async def update_device(self, device_id: str, update_data: DeviceNetworkUpdate) -> Optional[DeviceNetworkResponse]:
-        #อัปเดต Device Network
+    async def update_device(self, device_id: str, update_data: DeviceNetworkUpdate) -> tuple:
+        """อัปเดต Device Network — returns (DeviceNetworkResponse, ipam_notifications)"""
         try:
+            ipam_notifications = []
+
             existing_device = await self.prisma.devicenetwork.find_unique(where={"id": device_id})
 
             if not existing_device:
@@ -440,7 +479,6 @@ class DeviceNetworkService:
             # Foreign keys - ตรวจสอบก่อนอัปเดต
             foreign_keys_to_validate = {}
             
-            # Uncommented fields (requires 'prisma generate')
             if update_data.os_id is not None:
                 foreign_keys_to_validate['os_id'] = update_data.os_id
                 update_dict["os_id"] = update_data.os_id
@@ -463,7 +501,6 @@ class DeviceNetworkService:
 
             # NBI/ODL Fields
             if update_data.node_id is not None:
-                # ตรวจสอบว่า node_id ไม่ซ้ำกับ device อื่น
                 if update_data.node_id != existing_device.node_id:
                     duplicate = await self.prisma.devicenetwork.find_unique(
                         where={"node_id": update_data.node_id}
@@ -481,24 +518,109 @@ class DeviceNetworkService:
             if update_data.datapath_id is not None:
                 update_dict["datapath_id"] = update_data.datapath_id
 
-            if update_data.management_protocol is not None:
-                update_dict["management_protocol"] = update_data.management_protocol.value
-
-            if update_data.datapath_id is not None:
-                update_dict["datapath_id"] = update_data.datapath_id
-
-            # NETCONF Connection Fields
             if update_data.netconf_host is not None:
                 update_dict["netconf_host"] = update_data.netconf_host
-                # ถ้าเปลี่ยน IP Management ใหม่ ให้ผูก phpIPAM ใหม่ด้วย
-                if update_data.netconf_host != existing_device.netconf_host:
-                    new_phpipam_id = await self._sync_ip_to_phpipam(
-                        ip_address=update_data.netconf_host,
+
+            # ======= IPAM: Handle IP changes =======
+            # Determine the effective management IP (new or existing)
+            new_netconf = update_data.netconf_host if update_data.netconf_host is not None else existing_device.netconf_host
+            new_ip = update_data.ip_address if update_data.ip_address is not None else existing_device.ip_address
+            effective_mgmt_ip = new_netconf or new_ip
+
+            old_mgmt_ip = existing_device.netconf_host or existing_device.ip_address
+
+            # ======= IPAM: Handle IP changes =======
+            new_status = update_dict.get("status", existing_device.status)
+            new_status_str = new_status.value if hasattr(new_status, "value") else str(new_status)
+            new_status_str = new_status_str.split('.')[-1].upper()
+            
+            old_status_raw = existing_device.status
+            old_status_str = old_status_raw.value if hasattr(old_status_raw, "value") else str(old_status_raw)
+            old_status_str = old_status_str.split('.')[-1].upper()
+            status_changed = update_data.status is not None and new_status_str != old_status_str
+            name_changed = update_data.device_name is not None and update_dict.get("device_name") != existing_device.device_name
+            mac_changed = update_data.mac_address is not None and update_dict.get("mac_address") != existing_device.mac_address
+
+            # 1. Management IP
+            old_mgmt_ip = existing_device.ip_address
+            new_mgmt_ip = update_dict.get("ip_address", existing_device.ip_address)
+            ip_changed = (new_mgmt_ip != old_mgmt_ip) and new_mgmt_ip is not None
+            never_booked = (not existing_device.phpipam_address_id) and new_mgmt_ip is not None
+
+            print(f"[IPAM-UPDATE] mgmt_ip={new_mgmt_ip}, old_mgmt_ip={old_mgmt_ip}, ip_changed={ip_changed}")
+
+            if ip_changed or never_booked:
+                if existing_device.phpipam_address_id and ip_changed:
+                    # Release old
+                    release_result = await self.phpipam_service.release_ip_safe(existing_device.phpipam_address_id)
+                    ipam_notifications.append(self._build_ipam_notification(release_result))
+                
+                # Book new mgmt IP
+                book_result = await self.phpipam_service.book_ip(
+                    ip_address=new_mgmt_ip,
+                    hostname=update_dict.get("device_name", existing_device.device_name),
+                    mac_address=update_dict.get("mac_address", existing_device.mac_address),
+                    purpose="Management IP",
+                    device_status=new_status_str
+                )
+                ipam_notifications.append(self._build_ipam_notification(book_result))
+                if book_result.get("success"):
+                    update_dict["phpipam_address_id"] = book_result.get("phpipam_address_id")
+            
+            elif existing_device.phpipam_address_id and (status_changed or name_changed or mac_changed):
+                # Sync updates for mgmt IP
+                target_tag = "1" if new_status_str == "ONLINE" else "2"
+                update_kwargs = {"tag": target_tag, "state": target_tag}
+                if name_changed:
+                    update_kwargs["hostname"] = update_dict.get("device_name")
+                    update_kwargs["description"] = f"[Management IP] {update_kwargs['hostname']}"[:64]
+                if mac_changed:
+                    mac_addr = update_dict.get("mac_address")
+                    normalized_mac = self.phpipam_service._normalize_mac(mac_addr) if mac_addr else None
+                    if normalized_mac:
+                        update_kwargs["mac"] = normalized_mac
+                await self.phpipam_service.update_ip_address(existing_device.phpipam_address_id, **update_kwargs)
+
+            # 2. Netconf IP
+            old_netconf_ip = existing_device.netconf_host
+            new_netconf_ip = update_dict.get("netconf_host", existing_device.netconf_host)
+            netconf_changed = (new_netconf_ip != old_netconf_ip) and new_netconf_ip is not None
+            
+            print(f"[IPAM-UPDATE] netconf_ip={new_netconf_ip}, old_netconf_ip={old_netconf_ip}, netconf_changed={netconf_changed}")
+
+            if netconf_changed:
+                if old_netconf_ip and old_netconf_ip != old_mgmt_ip:
+                    # Release old netconf IP dynamically
+                    old_nc_obj = await self.phpipam_service.search_ip(old_netconf_ip)
+                    if old_nc_obj and old_nc_obj.get("id"):
+                        nc_rel_result = await self.phpipam_service.release_ip_safe(str(old_nc_obj["id"]))
+                        ipam_notifications.append(self._build_ipam_notification(nc_rel_result))
+                
+                if new_netconf_ip and new_netconf_ip != new_mgmt_ip:
+                    nc_result = await self.phpipam_service.book_ip(
+                        ip_address=new_netconf_ip,
                         hostname=update_dict.get("device_name", existing_device.device_name),
-                        mac_address=update_dict.get("mac_address", existing_device.mac_address)
+                        mac_address=update_dict.get("mac_address", existing_device.mac_address),
+                        purpose="Netconf Host",
+                        device_status=new_status_str
                     )
-                    if new_phpipam_id:
-                        update_dict["phpipam_address_id"] = new_phpipam_id
+                    ipam_notifications.append(self._build_ipam_notification(nc_result))
+            elif not netconf_changed and new_netconf_ip and new_netconf_ip != new_mgmt_ip:
+                if status_changed or name_changed or mac_changed:
+                    # Update properties for existing netconf IP dynamically if it was booked
+                    nc_obj = await self.phpipam_service.search_ip(new_netconf_ip)
+                    if nc_obj and nc_obj.get("id"):
+                        target_tag = "1" if new_status_str == "ONLINE" else "2"
+                        nc_update_kwargs = {"tag": target_tag, "state": target_tag}
+                        if name_changed:
+                            nc_update_kwargs["hostname"] = update_dict.get("device_name")
+                            nc_update_kwargs["description"] = f"[Netconf Host] {nc_update_kwargs['hostname']}"[:64]
+                        if mac_changed:
+                            mac_addr = update_dict.get("mac_address")
+                            normalized_mac = self.phpipam_service._normalize_mac(mac_addr) if mac_addr else None
+                            if normalized_mac:
+                                nc_update_kwargs["mac"] = normalized_mac
+                        await self.phpipam_service.update_ip_address(str(nc_obj["id"]), **nc_update_kwargs)
 
             if update_data.netconf_port is not None:
                 update_dict["netconf_port"] = update_data.netconf_port
@@ -522,24 +644,50 @@ class DeviceNetworkService:
                 }
             )
 
-            return self._build_device_response(updated_device)
+            return self._build_device_response(updated_device), ipam_notifications
 
         except Exception as e:
             print(f"Error updating device: {e}")
             raise e
 
-    async def delete_device(self, device_id: str) -> bool:
-        #ลบ Device Network
+    async def delete_device(self, device_id: str) -> tuple:
+        """ลบ Device Network — returns (success: bool, ipam_notifications)"""
         try:
+            ipam_notifications = []
+
             existing_device = await self.prisma.devicenetwork.find_unique(
-                where={"id": device_id}
+                where={"id": device_id},
+                include={"interfaces": True}
             )
 
             if not existing_device:
                 raise ValueError("ไม่พบ Device Network ที่ต้องการลบ")
 
+            # ======= IPAM: Release device management IP =======
+            if existing_device.phpipam_address_id:
+                result = await self.phpipam_service.release_ip_safe(
+                    existing_device.phpipam_address_id
+                )
+                ipam_notifications.append(self._build_ipam_notification(result))
+
+            # ======= IPAM: Release netconf host IP =======
+            if existing_device.netconf_host and existing_device.netconf_host != existing_device.ip_address:
+                nc_obj = await self.phpipam_service.search_ip(existing_device.netconf_host)
+                if nc_obj and nc_obj.get("id"):
+                    nc_result = await self.phpipam_service.release_ip_safe(str(nc_obj["id"]))
+                    ipam_notifications.append(self._build_ipam_notification(nc_result))
+
+            # ======= IPAM: Release all interface IPs =======
+            if hasattr(existing_device, 'interfaces') and existing_device.interfaces:
+                for intf in existing_device.interfaces:
+                    if hasattr(intf, 'phpipam_address_id') and intf.phpipam_address_id:
+                        result = await self.phpipam_service.release_ip_safe(
+                            intf.phpipam_address_id
+                        )
+                        ipam_notifications.append(self._build_ipam_notification(result))
+
             await self.prisma.devicenetwork.delete(where={"id": device_id})
-            return True
+            return True, ipam_notifications
 
         except Exception as e:
             print(f"Error deleting device: {e}")

--- a/backend/app/services/interface_service.py
+++ b/backend/app/services/interface_service.py
@@ -80,6 +80,15 @@ class InterfaceService:
             tp_id=interface.tp_id,
             port_number=interface.port_number,
             mac_address=interface.mac_address,
+            # IPAM fields
+            ip_address=getattr(interface, 'ip_address', None),
+            subnet_mask=getattr(interface, 'subnet_mask', None),
+            gateway=getattr(interface, 'gateway', None),
+            phpipam_address_id=getattr(interface, 'phpipam_address_id', None),
+            # Operational fields
+            speed=getattr(interface, 'speed', None),
+            duplex=getattr(interface, 'duplex', None),
+            mtu=getattr(interface, 'mtu', None),
             created_at=interface.createdAt,
             updated_at=interface.updatedAt,
             device=device_info

--- a/backend/app/services/odl_mount_service.py
+++ b/backend/app/services/odl_mount_service.py
@@ -18,6 +18,7 @@ from app.core.errors import OdlRequestError
 from app.schemas.request_spec import RequestSpec
 from app.core.logging import logger
 from app.database import get_prisma_client
+from app.services.phpipam_service import PhpipamService
 
 
 # Map ODL connection status string to DB enum value
@@ -50,6 +51,7 @@ class OdlMountService:
     
     def __init__(self):
         self.odl_client = OdlRestconfClient()
+        self.phpipam_service = PhpipamService()
         # Per-device lock to prevent concurrent mount/unmount on the same device
         self._device_locks: Dict[str, asyncio.Lock] = {}
     
@@ -234,6 +236,7 @@ class OdlMountService:
                                 "last_synced_at": datetime.utcnow()
                             }
                         )
+                        await self.phpipam_service.sync_device_status_to_ipam(device.id, "ONLINE")
                     return {
                         "success": True,
                         "message": f"Device {device.node_id} is already mounted and connected",
@@ -308,6 +311,7 @@ class OdlMountService:
                             "status": "OFFLINE"
                         }
                     )
+                    await self.phpipam_service.sync_device_status_to_ipam(device.id, "OFFLINE")
                 except Exception:
                     pass
             
@@ -354,6 +358,7 @@ class OdlMountService:
                         "last_synced_at": datetime.utcnow()
                     }
                 )
+                await self.phpipam_service.sync_device_status_to_ipam(device.id, "OFFLINE")
                 return {
                     "success": True,
                     "message": f"Device {device.node_id} was already unmounted (DB synced)",
@@ -388,6 +393,7 @@ class OdlMountService:
                     "last_synced_at": datetime.utcnow()
                 }
             )
+            await self.phpipam_service.sync_device_status_to_ipam(device.id, "OFFLINE")
             
             return {
                 "success": True,
@@ -506,6 +512,9 @@ class OdlMountService:
                     "last_synced_at": datetime.utcnow()
                 }
             )
+            # Sync phpIPAM tag to match new device status
+            if str(device.status) != device_status:
+                await self.phpipam_service.sync_device_status_to_ipam(device.id, device_status)
             
             return {
                 "synced": True,
@@ -669,6 +678,7 @@ class OdlMountService:
                         "last_synced_at": datetime.utcnow()
                     }
                 )
+                await self.phpipam_service.sync_device_status_to_ipam(device_id, "ONLINE")
                 
                 return {
                     "success": True,
@@ -691,6 +701,7 @@ class OdlMountService:
                         "last_synced_at": datetime.utcnow()
                     }
                 )
+                await self.phpipam_service.sync_device_status_to_ipam(device_id, "OFFLINE")
                 
                 return {
                     "success": False,
@@ -720,6 +731,7 @@ class OdlMountService:
                 "last_synced_at": datetime.utcnow()
             }
         )
+        await self.phpipam_service.sync_device_status_to_ipam(device_id, "OFFLINE")
         
         return {
             "success": False,
@@ -766,6 +778,7 @@ class OdlMountService:
                         "status": "OFFLINE",
                     }
                 )
+                await self.phpipam_service.sync_device_status_to_ipam(device.id, "OFFLINE")
 
             # Step 3: Wait for ODL session teardown
             logger.info(f"[force-remount] Waiting {cleanup_wait}s for ODL session teardown")

--- a/backend/app/services/odl_sync_service.py
+++ b/backend/app/services/odl_sync_service.py
@@ -14,6 +14,7 @@ from app.clients.odl_restconf_client import OdlRestconfClient
 from app.schemas.request_spec import RequestSpec
 from app.core.logging import logger
 from app.database import get_prisma_client
+from app.services.phpipam_service import PhpipamService
 
 
 # Map ODL connection status string to DB enum value
@@ -46,6 +47,7 @@ class OdlSyncService:
     
     def __init__(self):
         self.odl_client = OdlRestconfClient()
+        self.phpipam_service = PhpipamService()
     
     async def get_odl_mounted_nodes(self) -> List[Dict[str, Any]]:
         """
@@ -183,6 +185,9 @@ class OdlSyncService:
                                 "ip_address": odl_node.get("host") or device.ip_address,
                             }
                         )
+                        # Sync phpIPAM tag to match new device status
+                        if str(device.status) != new_status:
+                            await self.phpipam_service.sync_device_status_to_ipam(device.id, new_status)
                         
                         logger.info(f"[NETCONF-Sync] {node_id} ({odl_node.get('host','?')}): connection={odl_node['connection_status']} → status={new_status}")
                         result["synced"].append({
@@ -227,6 +232,8 @@ class OdlSyncService:
                                 "last_synced_at": datetime.utcnow()
                             }
                         )
+                        # Sync phpIPAM tag → Offline
+                        await self.phpipam_service.sync_device_status_to_ipam(device.id, "OFFLINE")
                         logger.info(f"[NETCONF-Sync] {device.node_id}: not in ODL topology → status=OFFLINE (unmounted)")
                         result["synced"].append({
                             "node_id": device.node_id,
@@ -299,6 +306,7 @@ class OdlSyncService:
                                 "last_synced_at": datetime.utcnow()
                             }
                         )
+                        await self.phpipam_service.sync_device_status_to_ipam(d.id, "OFFLINE")
                         result["synced"].append({
                             "device_id": d.id,
                             "node_id": d.node_id,
@@ -369,6 +377,7 @@ class OdlSyncService:
                                     "last_synced_at": datetime.utcnow()
                                 }
                             )
+                            await self.phpipam_service.sync_device_status_to_ipam(d.id, "OFFLINE")
 
             # 4. Sync each ODL node to the DB
             for odl_nd in odl_node_data:
@@ -421,6 +430,9 @@ class OdlSyncService:
                         "last_synced_at": datetime.utcnow()
                     }
                 )
+                # Sync phpIPAM tag → Online
+                if str(device.status) != "ONLINE":
+                    await self.phpipam_service.sync_device_status_to_ipam(device.id, "ONLINE")
 
                 # 5. Sync Interfaces
                 for conn in connectors:
@@ -706,6 +718,9 @@ class OdlSyncService:
                     "last_synced_at": datetime.utcnow(),
                 }
             )
+            # Sync phpIPAM tag to match new device status
+            if str(device.status) != new_status:
+                await self.phpipam_service.sync_device_status_to_ipam(device.id, new_status)
 
             logger.info(
                 f"[SingleSync] {node_id} ({protocol}): {previous_status} → {new_status} "

--- a/backend/app/services/phpipam_service.py
+++ b/backend/app/services/phpipam_service.py
@@ -96,6 +96,10 @@ class PhpipamService:
                 
                 if response.status_code in [200, 201]:
                     return response.json()
+                elif response.status_code == 404:
+                    # phpIPAM returns 404 for empty results (e.g. empty subnet, IP not found)
+                    # This is normal — not an error. Return parsed body so callers can check.
+                    return response.json()
                 else:
                     print(f"[phpIPAM] Request failed: {method} {endpoint} - {response.status_code} - {response.text}")
                     return None
@@ -243,6 +247,30 @@ class PhpipamService:
             return result.get("data", [])
         return []
     
+    # ========= MAC Address Validation =========
+    
+    @staticmethod
+    def _is_valid_mac(mac: str) -> bool:
+        """Check if MAC address is valid for phpIPAM (XX:XX:XX:XX:XX:XX or XX-XX-XX-XX-XX-XX)"""
+        if not mac:
+            return False
+        import re
+        # Accept formats: 00:11:22:33:44:55, 00-11-22-33-44-55, 001122334455, 0011.2233.4455
+        mac_clean = re.sub(r'[.:\-]', '', mac)
+        return bool(re.match(r'^[0-9a-fA-F]{12}$', mac_clean))
+    
+    @staticmethod
+    def _normalize_mac(mac: str) -> Optional[str]:
+        """Normalize MAC to XX:XX:XX:XX:XX:XX format for phpIPAM"""
+        if not mac:
+            return None
+        import re
+        mac_clean = re.sub(r'[.:\-]', '', mac)
+        if not re.match(r'^[0-9a-fA-F]{12}$', mac_clean):
+            return None  # Invalid MAC — skip
+        # Format as AA:BB:CC:DD:EE:FF
+        return ':'.join(mac_clean[i:i+2] for i in range(0, 12, 2)).lower()
+
     # ========= IP Address Management =========
     
     async def create_ip_address(
@@ -263,8 +291,14 @@ class PhpipamService:
             data["hostname"] = hostname
         if description:
             data["description"] = description
+        
+        # Validate & normalize MAC before sending to phpIPAM
         if mac_address:
-            data["mac"] = mac_address
+            normalized_mac = self._normalize_mac(mac_address)
+            if normalized_mac:
+                data["mac"] = normalized_mac
+            else:
+                print(f"[phpIPAM] Skipping invalid MAC '{mac_address}' — not sending to phpIPAM")
         
         # Add any additional fields
         data.update(kwargs)
@@ -395,3 +429,541 @@ class PhpipamService:
             print(f"[phpIPAM] Error auto-syncing IP {ip_address}: {e}")
             
         return None
+
+    # ========= Smart Booking (with Notification) =========
+
+    async def book_ip(
+        self,
+        ip_address: str,
+        hostname: str,
+        mac_address: Optional[str] = None,
+        description: Optional[str] = None,
+        subnet_id: Optional[str] = None,
+        purpose: str = "Management IP",
+        device_status: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """
+        Smart IP booking with full notification support.
+        Returns IpamResult-compatible dict:
+        { success, code, phpipam_address_id, ip_address, subnet_info, error_message }
+
+        Flow:
+        1. phpIPAM disabled → IPAM_DISABLED
+        2. Search IP → ถ้าเจอ → IPAM_ALREADY_EXISTS (reuse)
+        3. ถ้ามี subnet_id → book ตรงใน subnet นั้น (Picker mode)
+           ถ้าไม่มี → auto-find subnet ที่ match (Manual mode)
+        4. Book IP → IPAM_BOOKED | IPAM_CONFLICT
+        5. ไม่เจอ subnet → IPAM_NO_SUBNET
+        """
+        if not self.enabled:
+            return {
+                "success": False,
+                "code": "IPAM_DISABLED",
+                "ip_address": ip_address,
+                "phpipam_address_id": None,
+                "subnet_info": None,
+                "error_message": "phpIPAM integration is not enabled"
+            }
+
+        if not ip_address:
+            return {
+                "success": False,
+                "code": "IPAM_NO_SUBNET",
+                "ip_address": None,
+                "phpipam_address_id": None,
+                "subnet_info": None,
+                "error_message": "No IP address provided"
+            }
+
+        try:
+            target_tag = "1"
+            if device_status:
+                status_str = device_status.value if hasattr(device_status, "value") else str(device_status)
+                status_str = status_str.split('.')[-1].upper()
+                target_tag = "1" if status_str == "ONLINE" else "2"
+
+            # Step 1: Check if IP already exists in phpIPAM
+            existing_ip = await self.search_ip(ip_address)
+            if existing_ip and existing_ip.get("id"):
+                existing_id = str(existing_ip.get("id"))
+                
+                # Get subnet info for notification
+                subnet_info = None
+                existing_subnet_id = existing_ip.get("subnetId")
+                if existing_subnet_id:
+                    subnet_data = await self.get_subnet(str(existing_subnet_id))
+                    if subnet_data:
+                        subnet_info = f"{subnet_data.get('subnet')}/{subnet_data.get('mask')}"
+
+                # Update existing record with new hostname/MAC/tag → reactivate
+                update_data = {"tag": target_tag, "state": target_tag}
+                if hostname:
+                    update_data["hostname"] = hostname
+                if mac_address:
+                    normalized = self._normalize_mac(mac_address)
+                    if normalized:
+                        update_data["mac"] = normalized
+                if description:
+                    update_data["description"] = description[:64]
+                else:
+                    update_data["description"] = f"[{purpose}] {hostname}"[:64]
+
+                await self.update_ip_address(existing_id, **update_data)
+
+                return {
+                    "success": True,
+                    "code": "IPAM_ALREADY_EXISTS",
+                    "phpipam_address_id": existing_id,
+                    "ip_address": ip_address,
+                    "subnet_info": subnet_info,
+                    "error_message": None
+                }
+
+            # Step 2: Find target subnet
+            target_subnet_id = subnet_id
+            target_subnet_info = None
+
+            if target_subnet_id:
+                # Picker mode: use the provided subnet_id directly
+                subnet_data = await self.get_subnet(target_subnet_id)
+                if subnet_data:
+                    target_subnet_info = f"{subnet_data.get('subnet')}/{subnet_data.get('mask')}"
+            else:
+                # Manual mode: auto-find subnet that contains this IP
+                target_ip = ipaddress.ip_address(ip_address)
+                subnets = await self.get_subnets()
+
+                for subnet in subnets:
+                    try:
+                        network = ipaddress.ip_network(
+                            f"{subnet['subnet']}/{subnet['mask']}", strict=False
+                        )
+                        if target_ip in network:
+                            target_subnet_id = str(subnet["id"])
+                            target_subnet_info = f"{subnet['subnet']}/{subnet['mask']}"
+                            break
+                    except (ValueError, KeyError):
+                        continue
+
+            if not target_subnet_id:
+                return {
+                    "success": False,
+                    "code": "IPAM_NO_SUBNET",
+                    "phpipam_address_id": None,
+                    "ip_address": ip_address,
+                    "subnet_info": None,
+                    "error_message": f"No subnet found that contains IP {ip_address}"
+                }
+
+            # Step 3: Book IP in the target subnet
+            desc = (description or f"[{purpose}] {hostname}")[:64]
+            new_ip = await self.create_ip_address(
+                subnet_id=target_subnet_id,
+                ip_address=ip_address,
+                hostname=hostname,
+                mac_address=mac_address,
+                description=desc,
+                tag=target_tag,
+                state=target_tag
+            )
+
+            if new_ip and new_ip.get("id"):
+                new_id = str(new_ip.get("id"))
+                # phpIPAM ignores tag during POST (defaults to 1=Used).
+                # Explicitly PATCH to set the correct tag if device is not ONLINE.
+                if target_tag != "1":
+                    await self.update_ip_address(new_id, tag=target_tag, state=target_tag)
+                    print(f"[phpIPAM] Post-create PATCH tag={target_tag} for {ip_address} (id={new_id})")
+
+                return {
+                    "success": True,
+                    "code": "IPAM_BOOKED",
+                    "phpipam_address_id": new_id,
+                    "ip_address": ip_address,
+                    "subnet_info": target_subnet_info,
+                    "error_message": None
+                }
+            else:
+                return {
+                    "success": False,
+                    "code": "IPAM_CONFLICT",
+                    "phpipam_address_id": None,
+                    "ip_address": ip_address,
+                    "subnet_info": target_subnet_info,
+                    "error_message": f"phpIPAM rejected IP {ip_address} — possible overlap or conflict"
+                }
+
+        except Exception as e:
+            print(f"[phpIPAM] Error booking IP {ip_address}: {e}")
+            return {
+                "success": False,
+                "code": "IPAM_CONFLICT",
+                "phpipam_address_id": None,
+                "ip_address": ip_address,
+                "subnet_info": None,
+                "error_message": str(e)
+            }
+
+    async def release_ip_safe(self, phpipam_address_id: str) -> Dict[str, Any]:
+        """
+        Retire IP in phpIPAM (soft release — เปลี่ยนเป็น Reserved เพื่อไม่ให้ใช้งานต่อเอง).
+        
+        เปลี่ยน tag เป็น 3 (Reserved) + ล้าง hostname
+        ทำให้ IP ยังอยู่ใน phpIPAM (เห็นใน space map ว่า "Reserved")
+        User สามารถเลือกใช้ซ้ำ หรือ admin จะลบ manual ก็ได้
+        
+        phpIPAM Tags: 1=Online, 2=Offline, 3=Reserved, 4=DHCP
+        """
+        if not self.enabled:
+            return {
+                "success": False,
+                "code": "IPAM_DISABLED",
+                "phpipam_address_id": phpipam_address_id,
+                "ip_address": None,
+                "subnet_info": None,
+                "error_message": "phpIPAM integration is not enabled"
+            }
+
+        try:
+            # Get IP info before updating (for notification message)
+            ip_info = await self.get_ip_address(phpipam_address_id)
+            ip_address = ip_info.get("ip") if ip_info else None
+            old_hostname = ip_info.get("hostname", "") if ip_info else ""
+            old_description = ip_info.get("description", "") if ip_info else ""
+
+            # Soft release: set tag=2 (Offline), clear hostname, mark description
+            from datetime import datetime
+            release_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+            release_desc = f"[Released {release_timestamp}] was: {old_hostname}"[:64]
+            updated = await self.update_ip_address(
+                phpipam_address_id,
+                tag="3",  # phpIPAM tag 3 = Reserved
+                state="3", # Support for environments expecting state
+                hostname="",  # ล้าง hostname — แสดงว่าไม่มี device ใช้อยู่
+                description=release_desc,
+                mac=""  # ล้าง MAC — ไม่ผูกกับ device แล้ว
+            )
+
+            if updated:
+                return {
+                    "success": True,
+                    "code": "IPAM_RELEASED",
+                    "phpipam_address_id": phpipam_address_id,
+                    "ip_address": ip_address,
+                    "subnet_info": None,
+                    "error_message": None
+                }
+            else:
+                return {
+                    "success": False,
+                    "code": "IPAM_RELEASE_FAILED",
+                    "phpipam_address_id": phpipam_address_id,
+                    "ip_address": ip_address,
+                    "subnet_info": None,
+                    "error_message": f"Failed to retire IP {phpipam_address_id} in phpIPAM"
+                }
+        except Exception as e:
+            print(f"[phpIPAM] Error retiring IP {phpipam_address_id}: {e}")
+            return {
+                "success": False,
+                "code": "IPAM_RELEASE_FAILED",
+                "phpipam_address_id": phpipam_address_id,
+                "ip_address": None,
+                "subnet_info": None,
+                "error_message": str(e)
+            }
+
+    # ========= Device Status → phpIPAM Sync (centralized) =========
+
+    async def sync_device_status_to_ipam(
+        self,
+        device_id: str,
+        new_status: str,
+    ) -> None:
+        """
+        Sync device ONLINE/OFFLINE status → phpIPAM tag for all IPs belonging to this device.
+
+        This is a fire-and-forget helper that any service can call after changing
+        DeviceNetwork.status in the DB. It will:
+          1. Look up the device's phpipam_address_id (Management IP)
+          2. Look up the device's netconf_host (if different from ip_address)
+          3. PATCH each phpIPAM record's tag to match the new status
+
+        phpIPAM Tags: 1=Used (Online), 2=Offline, 3=Reserved
+
+        Args:
+            device_id: DB primary key of the DeviceNetwork record
+            new_status: "ONLINE" or "OFFLINE" (case-insensitive)
+        """
+        if not self.enabled:
+            return
+
+        try:
+            from app.database import get_prisma_client
+            prisma = get_prisma_client()
+
+            device = await prisma.devicenetwork.find_unique(where={"id": device_id})
+            if not device:
+                return
+
+            # Normalize status string (handles Enum or plain str)
+            status_str = new_status.value if hasattr(new_status, "value") else str(new_status)
+            status_str = status_str.split(".")[-1].upper()
+            target_tag = "1" if status_str == "ONLINE" else "2"
+
+            # 1. Management IP (tracked via phpipam_address_id)
+            if device.phpipam_address_id:
+                try:
+                    await self.update_ip_address(
+                        device.phpipam_address_id,
+                        tag=target_tag,
+                        state=target_tag,
+                    )
+                    print(f"[phpIPAM-sync] device={device.device_name} mgmt_ip tag→{target_tag}")
+                except Exception as e:
+                    print(f"[phpIPAM-sync] Failed to update mgmt IP for {device.device_name}: {e}")
+
+            # 2. Netconf Host IP (if different from Management IP, looked up dynamically)
+            if device.netconf_host and device.netconf_host != device.ip_address:
+                try:
+                    nc_obj = await self.search_ip(device.netconf_host)
+                    if nc_obj and nc_obj.get("id"):
+                        await self.update_ip_address(
+                            str(nc_obj["id"]),
+                            tag=target_tag,
+                            state=target_tag,
+                        )
+                        print(f"[phpIPAM-sync] device={device.device_name} netconf_ip tag→{target_tag}")
+                except Exception as e:
+                    print(f"[phpIPAM-sync] Failed to update netconf IP for {device.device_name}: {e}")
+
+        except Exception as e:
+            # Never let IPAM sync break the calling service
+            print(f"[phpIPAM-sync] Error syncing device {device_id}: {e}")
+
+    # ========= Picker Data (for Frontend Dropdown) =========
+
+    async def get_subnets_for_picker(self) -> List[Dict[str, Any]]:
+        """
+        Return subnet list with usage info for dropdown picker.
+        Each item: { id, label, subnet, mask, description, usage_percent, free_hosts, total_hosts }
+        """
+        if not self.enabled:
+            return []
+
+        try:
+            subnets = await self.get_subnets()
+            picker_items = []
+
+            for subnet in subnets:
+                subnet_id = str(subnet.get("id"))
+                subnet_addr = subnet.get("subnet", "")
+                mask = subnet.get("mask", "")
+                description = subnet.get("description", "")
+
+                # Get usage info
+                usage = await self.get_subnet_usage(subnet_id)
+
+                free_hosts = 0
+                total_hosts = 0
+                usage_percent = 0.0
+
+                if usage:
+                    free_hosts = int(usage.get("freehosts", 0))
+                    total_hosts = int(usage.get("maxhosts", 0))
+                    usage_percent = float(usage.get("Used_percent", 0))
+
+                # Build readable label
+                desc_part = f" — {description}" if description else ""
+                label = f"{subnet_addr}/{mask}{desc_part} ({free_hosts} free)"
+
+                picker_items.append({
+                    "id": subnet_id,
+                    "label": label,
+                    "subnet": subnet_addr,
+                    "mask": mask,
+                    "description": description,
+                    "usage_percent": usage_percent,
+                    "free_hosts": free_hosts,
+                    "total_hosts": total_hosts,
+                })
+
+            return picker_items
+
+        except Exception as e:
+            print(f"[phpIPAM] Error getting subnets for picker: {e}")
+            return []
+
+    async def get_available_ips(self, subnet_id: str, limit: int = 100) -> Dict[str, Any]:
+        """
+        Calculate free IPs in a subnet.
+        IP ว่าง = ทั้ง IP ที่ไม่มี record + IP ที่ถูก retire แล้ว (tag=2 Offline)
+        Returns: { subnet_id, subnet, available_ips: [...], total_available }
+        """
+        if not self.enabled:
+            return {"subnet_id": subnet_id, "subnet": "", "available_ips": [], "total_available": 0}
+
+        try:
+            # Get subnet info
+            subnet_data = await self.get_subnet(subnet_id)
+            if not subnet_data:
+                return {"subnet_id": subnet_id, "subnet": "", "available_ips": [], "total_available": 0}
+
+            subnet_addr = subnet_data.get("subnet", "")
+            mask = subnet_data.get("mask", "")
+            network = ipaddress.ip_network(f"{subnet_addr}/{mask}", strict=False)
+
+            # Get existing addresses — only actively used IPs block availability
+            existing_addresses = await self.get_subnet_addresses(subnet_id)
+            
+            # IPs ที่ "ใช้อยู่จริง" = tag=1 (Online), tag=3 (Reserved), gateway
+            # IPs ที่ tag=2 (Offline/retired) ถือว่า "ว่าง" เลือกได้
+            actively_used_ips = set()
+            for addr in existing_addresses:
+                ip = addr.get("ip")
+                if not ip:
+                    continue
+                tag = str(addr.get("tag", "1"))
+                is_gw = addr.get("is_gateway") in (1, "1", True)
+                if is_gw or tag in ("1", "3"):  # Online, Reserved, Gateway
+                    actively_used_ips.add(ip)
+
+            # Calculate free IPs (skip network address, broadcast, and actively used IPs)
+            available_ips = []
+            for host in network.hosts():
+                ip_str = str(host)
+                if ip_str not in actively_used_ips:
+                    available_ips.append(ip_str)
+                    if len(available_ips) >= limit:
+                        break
+
+            return {
+                "subnet_id": subnet_id,
+                "subnet": f"{subnet_addr}/{mask}",
+                "available_ips": available_ips,
+                "total_available": len(available_ips),
+            }
+
+        except Exception as e:
+            print(f"[phpIPAM] Error getting available IPs for subnet {subnet_id}: {e}")
+            return {"subnet_id": subnet_id, "subnet": "", "available_ips": [], "total_available": 0}
+
+    async def get_space_map(self, subnet_id: str) -> Dict[str, Any]:
+        """
+        Return visual space map: every IP in the subnet with its status.
+        { subnet_id, subnet, mask, total_hosts, used, free, addresses: [...] }
+        """
+        if not self.enabled:
+            return {
+                "subnet_id": subnet_id, "subnet": "", "mask": "",
+                "total_hosts": 0, "used": 0, "free": 0, "addresses": []
+            }
+
+        try:
+            # Get subnet info
+            subnet_data = await self.get_subnet(subnet_id)
+            if not subnet_data:
+                return {
+                    "subnet_id": subnet_id, "subnet": "", "mask": "",
+                    "total_hosts": 0, "used": 0, "free": 0, "addresses": []
+                }
+
+            subnet_addr = subnet_data.get("subnet", "")
+            mask = subnet_data.get("mask", "")
+            network = ipaddress.ip_network(f"{subnet_addr}/{mask}", strict=False)
+
+            # Get existing addresses
+            existing_addresses = await self.get_subnet_addresses(subnet_id)
+            used_map = {}
+            
+            # Debug: log first address to see actual field names
+            if existing_addresses:
+                sample = existing_addresses[0]
+                print(f"[phpIPAM-spacemap] Sample address fields: {list(sample.keys())}")
+                print(f"[phpIPAM-spacemap] Sample address data: ip={sample.get('ip')}, tag={sample.get('tag')}, tagId={sample.get('tagId')}, state={sample.get('state')}")
+
+            for addr in existing_addresses:
+                ip = addr.get("ip")
+                if ip:
+                    is_gw = addr.get("is_gateway") in (1, "1", True)
+                    
+                    # phpIPAM returns tag in different ways depending on version:
+                    # - "tag": {"id": "2", ...}  (nested object)
+                    # - "tag": "2"               (string)
+                    # - "tag": 2                 (integer)
+                    # - "tagId": "2"             (separate field in some versions)
+                    raw_tag = addr.get("tag", "1")
+                    if isinstance(raw_tag, dict):
+                        tag = str(raw_tag.get("id", "1"))
+                    else:
+                        tag = str(raw_tag)
+                    
+                    # Fallback: some phpIPAM versions use tagId
+                    if tag == "1":
+                        tag_id_field = addr.get("tagId")
+                        if tag_id_field and str(tag_id_field) != "1":
+                            tag = str(tag_id_field)
+
+                    # Determine status based on phpIPAM tags
+                    # 1=Online(used), 2=Offline, 3=Reserved, 4=DHCP
+                    if is_gw:
+                        status = "gateway"
+                    elif tag == "3":
+                        status = "reserved"
+                    elif tag == "2":
+                        status = "offline"
+                    elif tag == "4":
+                        status = "dhcp"
+                    else:
+                        status = "used"  # tag=1 (Online) — กำลังใช้งานอยู่
+
+                    used_map[ip] = {
+                        "ip": ip,
+                        "status": status,
+                        "tag": tag,
+                        "hostname": addr.get("hostname"),
+                        "description": addr.get("description"),
+                        "address_id": str(addr.get("id", "")),
+                        "mac": addr.get("mac"),
+                    }
+
+            # Build full space map
+            addresses = []
+            used_count = 0
+            total_hosts = 0
+
+            for host in network.hosts():
+                ip_str = str(host)
+                total_hosts += 1
+
+                if ip_str in used_map:
+                    addresses.append(used_map[ip_str])
+                    used_count += 1
+                else:
+                    addresses.append({
+                        "ip": ip_str,
+                        "status": "free",
+                        "tag": None,
+                        "hostname": None,
+                        "description": None,
+                        "address_id": None,
+                        "mac": None,
+                    })
+
+            return {
+                "subnet_id": subnet_id,
+                "subnet": subnet_addr,
+                "mask": mask,
+                "total_hosts": total_hosts,
+                "used": used_count,
+                "free": total_hosts - used_count,
+                "addresses": addresses,
+            }
+
+        except Exception as e:
+            print(f"[phpIPAM] Error getting space map for subnet {subnet_id}: {e}")
+            return {
+                "subnet_id": subnet_id, "subnet": "", "mask": "",
+                "total_hosts": 0, "used": 0, "free": 0, "addresses": []
+            }
+

--- a/backend/app/services/zabbix_notification_service.py
+++ b/backend/app/services/zabbix_notification_service.py
@@ -24,6 +24,7 @@ from app.normalizers.zabbix import (
     normalize_zabbix_event,
 )
 from app.database import get_prisma_client
+from app.services.phpipam_service import PhpipamService
 
 
 class ZabbixNotificationService:
@@ -76,6 +77,7 @@ class ZabbixNotificationService:
 
     def __init__(self):
         self.slack = SlackClient()
+        self.phpipam_service = PhpipamService()
         self._event_history: List[Dict[str, Any]] = []
         self._max_history = 200
         self._db_updates = 0
@@ -644,6 +646,8 @@ class ZabbixNotificationService:
                 where={"id": device.id},
                 data={"status": new_status},
             )
+            # Sync phpIPAM tag to match new device status
+            await self.phpipam_service.sync_device_status_to_ipam(device.id, new_status)
             logger.info(
                 f"[ZabbixDB] Device reachability {device.device_name}: "
                 f"{old_status} → {new_status}"


### PR DESCRIPTION
Integrate phpIPAM across APIs and services: auto-book/release IPs, sync device status, and surface IPAM notifications to the frontend. Key changes:

- API: device create/update/delete responses now include ipam_notifications; interfaces sync auto-books discovered IPs and returns ipam_notifications. New IPAM endpoints: /subnets/picker, /subnets/{id}/available, /subnets/{id}/space-map.
- Models: added IPAM fields (phpipam_address_id, ip fields) and new IPAM notification/result/picker/space-map response models.
- DeviceNetworkService: booking, releasing and updating phpIPAM records during create/update/delete; builds user-facing notifications. Methods now return tuples (entity, ipam_notifications).
- PhpipamService: robust support for booking (book_ip), safe release (release_ip_safe), MAC validation/normalization, search handling, and sync_device_status_to_ipam helper; improved HTTP 404 handling.
- InterfaceService: map and expose IPAM and operational fields on interface responses.
- ODL mount/sync services: call phpipam sync helper to keep phpIPAM tags in sync with device ONLINE/OFFLINE state.
- Minor refactor: rename local interfaces list to result_interfaces in interfaces API and add phpipam_address_id to interface payloads.

These changes enable automatic IPAM workflows and provide frontend-friendly notifications for IP booking/release operations.